### PR TITLE
Fix /bin/sh: 1: set: Illegal option -o pipefail

### DIFF
--- a/make/targets/golang/test-unit.mk
+++ b/make/targets/golang/test-unit.mk
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 
 test-unit:


### PR DESCRIPTION
$ ls -al /bin/sh
lrwxrwxrwx 1 root root 4 May 29  2019 /bin/sh -> dash

$ make verify
GNU Make 4.1
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2014 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Reading makefiles...
/bin/sh: 1: set: Illegal option -o pipefail
vendor/github.com/openshift/build-machinery-go/make/targets/golang/../../lib/golang.mk:22: *** `go` is required with minimal version "1.13.4", detected version "1.13.4". You can override this check by using `make GO_REQUIRED_MIN_VERSION:=`.  Stop.